### PR TITLE
docs: add DESIGN.md and TESTING.md, split CLAUDE.md into operational guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository purpose
+
+This repo holds [Coder](https://coder.com/) workspace **templates** (Terraform) and the **container images** those templates provision — it is not an application codebase. There is currently one template/image pair, both named `homelab-workspace`:
+
+- `templates/kubernetes/homelab-workspace/` — Terraform template (`coder/coder` + `hashicorp/kubernetes` providers), deployed to a personal Kubernetes cluster.
+- `images/homelab-workspace/Dockerfile` — the Ubuntu-based image the template's pod runs.
+
+Almost all day-to-day change here is dependency bumps (Renovate) or edits to the template/image; there's no application logic, unit tests, or build step in the traditional sense.
+
+**For why these are built this way and how the pieces tie together, see [DESIGN.md](DESIGN.md). This file only covers how to work here.**
+
+## Commands
+
+No package-manager project lives here (`mise.toml` just pins `bun`/`node`/`terraform`/`tflint` tool versions). Local validation is `pre-commit`:
+
+```bash
+pre-commit run --all-files        # yamllint, markdownlint, shellcheck, hadolint, commitlint, terraform fmt/validate/tflint
+```
+
+Terraform checks scoped to the one template directory:
+
+```bash
+cd templates/kubernetes/homelab-workspace
+terraform fmt -check
+terraform validate
+tflint --config=../../../.tflint.hcl
+```
+
+CI (`.github/workflows/lint.yaml`) runs the same checks per file-type via reusable workflows in `ppat/github-workflows`, scoped to changed files on PRs, or everything on `workflow_dispatch`/schedule.
+
+There is no local way to build/publish the image or push the Coder template — see [TESTING.md](TESTING.md) for how a change actually gets exercised (including the `test_mode` flow), and the **Release flow** section below for how it ships for real.
+
+## Commit messages
+
+Commitlint (`commitlint.config.js`) enforces Conventional Commits.
+
+- Allowed scopes only: `cli-tools`, `dev-tools`, `deps`, `github-actions`, `release`, `renovate`, `terraform-provider`, `terraform-version`, or no scope. An unlisted scope fails commit-msg validation.
+- Body lines ≤120 chars, except `chore(deps)` commits (Renovate generates these verbatim, so that rule is relaxed for them).
+
+## Release flow
+
+`.github/workflows/release.yaml` triggers on changes to `images/homelab-workspace/**`, `templates/**`, or the release workflow/config itself, and on merge to `main`:
+
+1. `semantic-release` (`.releaserc.js`) cuts a version from commit history, updates `CHANGELOG.md`.
+2. The workspace image builds for `linux/amd64,linux/arm64` and pushes to the private registry.
+3. The Terraform template pushes to the live Coder deployment via `coder template push`, tagged with the released version.
+
+PRs and manual `workflow_dispatch` runs exercise this same pipeline in dry-run/test mode instead of publishing for real — see [TESTING.md](TESTING.md), which is the required reading before touching `templates/**` or `images/**`.
+
+## Where things live
+
+Quick orientation map — for what each piece is *for* and the decisions behind it, see [DESIGN.md](DESIGN.md).
+
+**Template** (`templates/kubernetes/homelab-workspace/`):
+
+| File | Contents |
+| --- | --- |
+| `terraform.tf` | Provider requirements/versions (Renovate-managed) |
+| `main.tf` | `coder_workspace`/`coder_workspace_owner` data sources, shared labels/path locals |
+| `parameters.tf` | User-facing `coder_parameter` inputs + sanitization locals |
+| `coder-agent.tf` | `coder_agent` resource: startup script, `coder stat` metadata |
+| `deployment.tf` / `configmap.tf` | Kubernetes Pod spec, volumes, ConfigMap |
+| `env.tf` | `coder_env` resources exposed to the agent |
+| `variables.tf` | `workspace_image`, `test_mode` — both supplied by the release workflow |
+| `script-agent-startup.sh` / `script-prepare-workspace.sh` | Scripts run on agent/workspace startup |
+
+**Image** (`images/homelab-workspace/Dockerfile`): three build stages — `base` (minimal bootstrap deps) → `system-base` (`unminimize` + full interactive toolset) → final stage (env vars into `/etc/environment`, fixed-UID/GID `coder` user, `USER coder`). All `apt`-touching `RUN` steps use BuildKit cache mounts — match that pattern when adding packages.
+
+**Renovate** (`.github/renovate.json` + `.github/renovate/*.json`): extends shared `ppat/renovate-presets` plus repo-local rules in `exceptions.json`, `image-cli-tools.json`, `template-terraform-provider.json` that set different automerge delays per dependency class.
+
+## Implementation gotchas
+
+Things that look arbitrary in the code but are load-bearing (full reasoning in [DESIGN.md](DESIGN.md)):
+
+- `deployment.tf`'s `system` volume is an `empty_dir`, rebuilt from the image on every pod start — a fix to anything under `/usr`, `/etc`, `/var` must go in the image or the init script, not be treated as a one-time patch.
+- The Dockerfile writes shared env vars to `/etc/environment` rather than using `ENV`, because `PATH` needs to be extended by a script running after the image is built, not fixed at build time.
+- `parameters.tf`'s `local.validated_*` regex allowlist is the only thing stopping `system_packages`/`preferred_nodes` from injecting shell metacharacters into the init container — any new list-type parameter must go through the same decode-then-validate step.
+
+## Working on a template or image change
+
+1. Make the change, run `pre-commit run --all-files` and the scoped `terraform validate`/`tflint` commands above.
+2. Follow [TESTING.md](TESTING.md) to exercise it via `test_mode` before merging — merging to `main` publishes to the real template/image with no separate promotion step.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,39 @@
+# DESIGN.md
+
+Why this repo is shaped the way it is, and how its pieces tie together as one system. For what each piece is and where it lives, see [README.md](README.md). For commands and implementation gotchas, see [CLAUDE.md](CLAUDE.md).
+
+## Intent
+
+One operator, one homelab Kubernetes cluster, one Coder deployment. This is not a multi-tenant or general-purpose template — it's optimized for a single person keeping their own dev environments current with minimal ongoing effort, not for flexibility across teams or clusters.
+
+## How the pieces tie together
+
+```mermaid
+flowchart LR
+    Renovate[Renovate dependency bumps] --> Image
+    Renovate --> Template
+
+    Image[Container image build] --> Push[coder template push]
+    Template[Terraform template] --> Push
+    Push --> Live[Live Coder deployment<br/>provisions workspace pods]
+```
+
+The image and template are two halves of one release, not independent artifacts: a release build produces an image tag, and the *same* pipeline run pushes the template pointing at that exact tag. There's no version matrix of "which template versions work with which image versions" to reason about — the pipeline guarantees there's only ever one pairing in play. The cost is coupling: an image-only fix still needs a template push (and vice versa) to ship.
+
+Renovate feeds both halves continuously (Terraform provider versions, image package/tool versions, GitHub Actions), so the day-to-day work in this repo is mostly reviewing and merging those bumps rather than writing new template/image logic.
+
+## Design tensions and decisions
+
+**Reproducible image vs. self-service packages.** A workspace user can request extra system packages via a template parameter rather than needing an image rebuild reviewed and released. That means the workspace's installed-package set isn't fully determined by the image alone — a deliberate trade of strict reproducibility for letting one-off tooling needs be self-served instead of turning into an image-change request every time.
+
+**Shared persistence, not per-workspace isolation.** All workspaces provisioned from this template persist their home directory (and installed tools like Homebrew) onto one shared volume, isolated from each other only logically rather than through separate storage. For a single-operator homelab, this is simpler to provision and reason about than storage-per-workspace, at the cost of weaker isolation between workspaces than a multi-tenant design would want.
+
+**No staging environment, so the release pipeline carries its own rehearsal path.** There's exactly one live template and one live cluster — no separate staging Coder deployment to try changes against first. Rather than accept "every merge to main is a live-fire test," the release pipeline itself can run in a mode that exercises a real build and a real (but disposable, clearly-named) template push without touching the production template or its persistent state. That path is what makes it safe to iterate on template/image changes at the same pace as everything else in the repo. See [TESTING.md](TESTING.md) for how to use it.
+
+**Unprivileged by default.** The workspace itself runs as an unprivileged, non-root, fixed-identity container. Anything that genuinely needs elevated privilege (installing packages, preparing shared volume state) is scoped to a narrow, short-lived setup step that runs before the workspace shell exists, not to something the workspace user can reach into.
+
+## Outcomes targeted
+
+- One operator can keep dependencies current and ship template/image changes at low ongoing effort, without a fleet of environments to maintain.
+- Changes can be exercised for real before they affect the template already in use — safe iteration without a staging cluster.
+- Workspace users get self-service customization without being able to affect anything beyond their own workspace's package set and environment.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # coder
 
-Templates and Images for [Coder](https://coder.com/) workspaces.
+Terraform templates and container images for [Coder](https://coder.com/) workspaces, running on a personal Kubernetes homelab cluster.
+
+## Contents
+
+- **`templates/kubernetes/homelab-workspace/`** — the Coder/Kubernetes Terraform template that provisions a workspace pod.
+- **`images/homelab-workspace/`** — the Ubuntu-based container image that pod runs.
+
+Template and image are versioned and released together; see [DESIGN.md](DESIGN.md) for why. Dependency versions (Terraform providers, image packages, GitHub Actions) are kept current mostly by Renovate.
+
+## Docs
+
+- **[DESIGN.md](DESIGN.md)** — why the template and image are built the way they are: trade-offs considered, decisions made, targeted outcomes.
+- **[TESTING.md](TESTING.md)** — how to validate a change, including exercising it against the real cluster without touching production workspace data.
+- **[CLAUDE.md](CLAUDE.md)** — commands and conventions for working in this repo with Claude Code.
+- **[CHANGELOG.md](CHANGELOG.md)** — generated release history (semantic-release).
+
+## Contributing
+
+Commit messages follow Conventional Commits, enforced by commitlint — see [CLAUDE.md](CLAUDE.md#commit-messages) for the allowed scopes. Releases and publishing are fully automated from `main`; see [DESIGN.md](DESIGN.md#template--image-release-together) and [TESTING.md](TESTING.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,28 @@
+# TESTING.md
+
+How changes to the template or image get verified before they can affect production. There's no separate test suite or staging environment (see [DESIGN.md](DESIGN.md)) — verification is the release pipeline itself, run in a mode that exercises everything a real release would except the parts that would affect the live template or its persistent state.
+
+## Intent
+
+A change to `templates/**` or `images/**` isn't trustworthy just because it parses (that's what lint/`terraform validate` already cover — see [CLAUDE.md](CLAUDE.md)). It's trustworthy once the same pipeline that would ship it has actually built the image and applied the template against the real cluster and provider. The test workflow's job is to make that possible on every PR, automatically, without any risk to the production template or the shared persistent state real workspaces depend on.
+
+## How it works
+
+The release pipeline (`.github/workflows/release.yaml`) runs in one of two modes, gated by whether it's allowed to publish for real:
+
+- **Dry-run mode** — automatic on any PR touching `images/**`, `templates/**`, or the release config itself, and available on demand via manual dispatch.
+- **Live mode** — runs on merge to `main`.
+
+Both modes run the identical sequence of stages; only what each stage is permitted to do at the end differs.
+
+## What each stage confirms
+
+1. **Versioning** — commit history since the last release is parsed to determine what the next version would be. In dry-run this stops short of tagging or publishing; it still confirms the commit history is well-formed enough to produce a valid release.
+2. **Image build** — the container image is built for every published architecture and pushed to the registry. This is the same build a live release performs, so it confirms the Dockerfile still produces a working image end to end — dry-run only changes the tag it's pushed under, not the build itself.
+3. **Template push** — the Terraform template is applied against the real Coder deployment and Kubernetes cluster, using the image just built. This confirms the template is actually valid against live provider/cluster state, not just internally consistent. Dry-run redirects this push to a separate, clearly-named template rather than the one real workspaces use, and backs it with disposable storage instead of the shared persistent volume — so nothing here can affect an existing workspace no matter what the change does.
+
+Because all three stages run for real in dry-run — just scoped away from production — a passing PR is a meaningful signal that a live release would also succeed, not a guess based on static checks alone.
+
+## After merge
+
+Merging to `main` is what flips the pipeline into live mode — there's no separate promotion step afterward. The dry-run pass on the PR is the actual release gate.


### PR DESCRIPTION
Establishes clear separation of concerns across docs: README.md for a human-facing overview, DESIGN.md for the intent/trade-offs behind the template+image release model, TESTING.md for how the dry-run release pipeline verifies changes, and CLAUDE.md trimmed to commands and implementation gotchas, cross-referencing the others instead of duplicating their content.