### PR TITLE
docs: describe how workspace environment layers compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ Things that look arbitrary in the code but are load-bearing (full reasoning in [
 - `deployment.tf`'s `system` volume is an `empty_dir`, rebuilt from the image on every pod start — a fix to anything under `/usr`, `/etc`, `/var` must go in the image or the init script, not be treated as a one-time patch.
 - The Dockerfile writes shared env vars to `/etc/environment` rather than using `ENV`, because `PATH` needs to be extended by a script running after the image is built, not fixed at build time.
 - `parameters.tf`'s `local.validated_*` regex allowlist is the only thing stopping `system_packages`/`preferred_nodes` from injecting shell metacharacters into the init container — any new list-type parameter must go through the same decode-then-validate step.
+- Adding a package/tool has three possible homes, and picking the wrong one is a real mistake, not a style choice — route by the rule in [DESIGN.md](DESIGN.md#where-the-workspace-environment-comes-from): universal + stable → image (`Dockerfile`); occasionally-needed + apt-only + too heavy to bake in → the template's `system_packages` parameter; personal, fast-moving, or not an apt package → the operator's dotfiles (a *different* repo — see below), never this one.
+
+## Neighbouring repos
+
+This repo is only the image+template layer. When a task's real cause is above or below that layer, it lives elsewhere — describe those repos briefly and link, don't reproduce their content (see [DESIGN.md](DESIGN.md#where-the-workspace-environment-comes-from) for how the layers compose):
+
+- **Coder platform** — the control plane these templates are pushed to, deployed to the cluster from [`homelab-ops-kubernetes-apps`](../homelab-ops-kubernetes-apps/apps/subsystems/coder/helm-release-coder.yaml) (Helm release) and [`homelab-ops-kubernetes-clusters`](../homelab-ops-kubernetes-clusters/clusters/homelab/kustomizations/apps-coder.yaml) (Flux Kustomization).
+- **Dotfiles** — the operator's per-workspace tooling (brew/mise/aqua), applied at provision time from [`dotfiles`](../dotfiles). Day-to-day tool installs belong here, not in the image or template.
 
 ## Working on a template or image change
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,7 +20,38 @@ flowchart LR
 
 The image and template are two halves of one release, not independent artifacts: a release build produces an image tag, and the *same* pipeline run pushes the template pointing at that exact tag. There's no version matrix of "which template versions work with which image versions" to reason about — the pipeline guarantees there's only ever one pairing in play. The cost is coupling: an image-only fix still needs a template push (and vice versa) to ship.
 
+The "live Coder deployment" this pushes to is itself provisioned separately, and what an operator actually works in is assembled from more layers than these two — see [Where the workspace environment comes from](#where-the-workspace-environment-comes-from) below.
+
 Renovate feeds both halves continuously (Terraform provider versions, image package/tool versions, GitHub Actions), so the day-to-day work in this repo is mostly reviewing and merging those bumps rather than writing new template/image logic.
+
+## Where the workspace environment comes from
+
+The environment an operator ends up working in isn't defined in one place — it's assembled in layers, and this repo owns only the middle two. Each layer downward is more shared, more reproducible, and changed less often; each layer upward is more personal and more self-service.
+
+```mermaid
+flowchart TB
+    subgraph platform [Coder platform · deployed from the homelab-ops repos]
+      Coder[Coder control plane<br/>Helm release, reconciled by Flux]
+    end
+    subgraph here [This repo · image + template, released together]
+      Image[Image layer<br/>baseline system packages, baked in]
+      Template[Template layer<br/>pod spec · extra apt packages · Homebrew prepared]
+    end
+    subgraph operator [Operator · applied from the dotfiles repo]
+      Dotfiles[Dotfiles<br/>day-to-day tooling via brew / mise / aqua]
+    end
+
+    Coder -->|provisions pod| Template
+    Image -->|pod root filesystem| Template
+    Template -->|running workspace| Dotfiles
+```
+
+- **Coder platform** — the control plane that runs these templates is itself deployed to the cluster elsewhere: the Helm release in [`homelab-ops-kubernetes-apps`](../homelab-ops-kubernetes-apps/apps/subsystems/coder/helm-release-coder.yaml) and the Flux Kustomization that wires it into the homelab cluster in [`homelab-ops-kubernetes-clusters`](../homelab-ops-kubernetes-clusters/clusters/homelab/kustomizations/apps-coder.yaml). This repo produces what runs *on* that platform, not the platform itself.
+- **Image** ([`Dockerfile`](images/homelab-workspace/Dockerfile)) — the baseline every workspace needs and nothing more. Baked in so startup is fast and the result reproducible; the cost of a rebuild-and-release is only worth paying for things wanted everywhere.
+- **Template** ([`deployment.tf`](templates/kubernetes/homelab-workspace/deployment.tf), [`script-prepare-workspace.sh`](templates/kubernetes/homelab-workspace/script-prepare-workspace.sh)) — builds the pod and closes the gap between the baseline image and a usable workspace: a small set of extra apt packages (build toolchains and the like — left out of the image because they're large and only occasionally needed, yet only sensibly obtained as apt packages) and Homebrew installed and prepared so the layer above has something to build on.
+- **Dotfiles** ([`dotfiles`](../dotfiles)) — at provision time the operator's dotfiles configure the shell/environment and install the actual day-to-day tooling via Homebrew, mise, and aqua. This is per-operator and changes constantly, so it lives with the operator rather than in the template.
+
+The rule that ties the layers together: a package or tool belongs in the *lowest* layer that still makes sense for it. Universal and stable → image. Occasionally-needed, apt-only, and too heavy to bake in → the template's `system_packages` parameter. Personal, fast-moving, or not an apt package → dotfiles. This is what keeps the image small and reproducible while still letting one-off needs be self-served — the same trade examined from the package angle in [Reproducible image vs. self-service packages](#design-tensions-and-decisions) below.
 
 ## Design tensions and decisions
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Terraform templates and container images for [Coder](https://coder.com/) workspa
 
 Template and image are versioned and released together; see [DESIGN.md](DESIGN.md) for why. Dependency versions (Terraform providers, image packages, GitHub Actions) are kept current mostly by Renovate.
 
+This repo is the middle of a larger stack: the Coder control plane is deployed separately (from the `homelab-ops-kubernetes-*` repos), and an operator's day-to-day tooling comes from their [dotfiles](../dotfiles) at provision time. See [DESIGN.md](DESIGN.md#where-the-workspace-environment-comes-from) for how the image, template, and those neighbours layer into one workspace environment.
+
 ## Docs
 
 - **[DESIGN.md](DESIGN.md)** — why the template and image are built the way they are: trade-offs considered, decisions made, targeted outcomes.

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-bun = "1.2.19"
-node = "24.11.1"
+bun = "1.3.14"
+node = "24.18.0"
 terraform = "1.15.8"
 tflint = "0.58.1"
 


### PR DESCRIPTION
Add a "Where the workspace environment comes from" section to DESIGN.md explaining how the Coder platform, image, template, and operator dotfiles layer into one workspace, with a Mermaid diagram and the "lowest layer that makes sense" package-placement rule. README and CLAUDE.md point to it rather than duplicating; CLAUDE.md gains an actionable package-routing rule and a brief "Neighbouring repos" section. Neighbouring repos are described briefly and linked via relative paths that resolve on GitHub and locally.