### PR TITLE
fix: disable dbus session bus autolaunch to stop orphaned daemons

### DIFF
--- a/images/homelab-workspace/Dockerfile
+++ b/images/homelab-workspace/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=cache-apt-${TARGETARCH},sharing=
     apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -yq --no-install-recommends man-db unminimize && \
     sed -i 's|xargs dpkg -S|xargs -r dpkg -S|g' /usr/bin/unminimize && \
-    echo -e 'y\ny' | /usr/bin/unminimize && \
+    printf 'y\ny\n' | /usr/bin/unminimize && \
     # install system packages needed within coder workspace image
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -yq \
       apt-file \
@@ -176,7 +176,15 @@ WORKDIR /tmp
 RUN echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' > /etc/environment && \
     echo 'PYTHONPYCACHEPREFIX=/var/cache/python' >> /etc/environment && \
     echo 'LC_ALL=en_US.UTF-8' >> /etc/environment && \
-    echo 'LANG=en_US.UTF-8' >> /etc/environment
+    echo 'LANG=en_US.UTF-8' >> /etc/environment && \
+    # This image has no dbus session bus and never will (no session manager, no systemd --user). Without
+    # this, anything that touches libsecret (e.g. git credential helpers) triggers `dbus-launch
+    # --autolaunch` to spawn a `dbus-daemon --session` hunting for one; it never finds one, is reparented
+    # to pid 1 once its parent exits, and never exits itself - orphans accumulate one per invocation for
+    # the life of the pod. `disabled:` is dbus's own documented value for "do not autolaunch, fail fast
+    # instead" (see dbus_bus_get behavior), which is what every libsecret-using tool here already handles
+    # as "no keyring available" rather than as an error.
+    echo 'DBUS_SESSION_BUS_ADDRESS=disabled:' >> /etc/environment
 
 ARG CODER_GID="10001"
 ARG CODER_UID="10001"
@@ -192,5 +200,5 @@ RUN groupadd --gid "${CODER_GID}" coder && \
     # package installation is complete, users of resulting image need not cache downloaded packages
     rm -f /etc/apt/apt.conf.d/keep-cache
 
-USER coder
+USER ${CODER_UID}:${CODER_GID}
 WORKDIR /home/coder


### PR DESCRIPTION
## Summary

- 31 orphaned `dbus-daemon --session` processes accumulated over a few
  days, reparented to pid 1. They leak from `dbus-launch --autolaunch`
  firing whenever something touches libsecret (git credential helpers,
  etc.) with no session bus present, spawns a daemon, and never exits
  since nothing ever owns/closes that session.
- Adds `DBUS_SESSION_BUS_ADDRESS=disabled:` to the shared
  `/etc/environment` block in the final Dockerfile stage, alongside
  `PATH`/`PYTHONPYCACHEPREFIX`/`LC_ALL`/`LANG`. This image has no
  session bus and never will (no session manager, no `systemd
  --user`), so this is a universal, stable fact about the image, not a
  workaround.
- Per instruction, this is the permanent fix only — no cleanup for
  existing orphans, which clear on the next pod restart.
- Also fixes the two pre-existing hadolint findings on this Dockerfile
  (SC3037, DL3066) since editing the file makes CI's `docker-files` job
  evaluate it again: `echo -e` swapped for the portable `printf`, and
  `USER coder` switched to the numeric `${CODER_UID}:${CODER_GID}`
  already used to create that user.

## Why `disabled:` is correct

Verified on the disposable `test` Coder workspace (not the operator's
live workspace) by downloading the same dbus/glib packages this image
would use (no image rebuild needed) and exercising both connection
paths a libsecret-using tool might take:

| | no `DBUS_SESSION_BUS_ADDRESS` (today) | `DBUS_SESSION_BUS_ADDRESS=disabled:` |
| --- | --- | --- |
| GDBus (`gdbus call --session ...`) | attempts autolaunch (gets as far as a machine-id lookup before failing in this sandbox) | fails in <5ms: `Unknown or unsupported transport "disabled" for address "disabled:"` |
| libdbus (`dbus-send --session ...`) | attempts autolaunch, fails only because no `$DISPLAY` | fails in <5ms: `Could not parse server address: Unknown address type` |
| `dbus-daemon` processes spawned | confirmed orphan-spawn is the live behavior on the operator's real workspace (31 present) | zero, in either path |

Both code paths recognize `disabled:` as a real (if unusual) transport
name and reject it immediately at address-parsing time, before any
autolaunch/spawn logic runs. The resulting error is the same *category*
of failure ("no session bus available") that already occurs in this
headless pod today — libsecret-based tools already have to handle that
case — so no caller's behavior changes beyond no longer spawning a
daemon nobody uses.

## Test plan

- [x] `pre-commit run --all-files` passes (including `hadolint`, now
      exercised since this PR touches the Dockerfile).
- [x] `terraform validate` / `tflint` unaffected (no template changes).
- [x] Verified `disabled:` suppresses autolaunch on the `test` Coder
      workspace as described above; not exercised via a full image
      rebuild since the dbus/glib behavior being tested doesn't depend
      on anything else in the image.
- [x] Real image build + `test_mode` push (this PR's CI) confirmed the
      Dockerfile still builds cleanly with the new `/etc/environment`
      line and numeric `USER`.

Ref: ppat/dotfiles#771
