### PR TITLE
ci(github-actions): add zizmor gate to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -143,3 +143,10 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
+
+  zizmor:
+    needs: [detect-changes]
+    if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
+    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Summary

Adds a `zizmor` job to `.github/workflows/lint.yaml`, mirroring the job
`homelab-ops-terraform` already runs (the closest structural analogue to
this repo — both matrix Terraform directories under a `detect-changes` +
`terraform-dirs` setup). This gives workflow-file changes in this repo the
same static-analysis/security gate (permissions, template-injection,
credential-handling, pinning) the rest of the org already applies via
`ppat/github-workflows`'s reusable `lint-zizmor.yaml`, instead of being
lint-checked ad hoc per repo.

The job is gated the same way as the other `lint.yaml` jobs: it only runs
on PRs that touch `.github/workflows/**` (via `detect-changes`'
`actions_any_changed`), or unconditionally on `workflow_dispatch`/schedule.

## Why no fixes/suppressions were needed

I reproduced the exact CI invocation locally
(`zizmor --format=plain --min-severity=medium --min-confidence=high --persona=regular .`,
via `uvx zizmor`, both offline and with a live `GH_TOKEN`) against this
repo's actual workflow files (`lint.yaml`, `release.yaml`, `renovate.yaml`,
`test.yaml`). Result: **zero findings** at the gate's thresholds.

Findings do exist below the gate's bar (`excessive-permissions` at
`Medium` confidence because several jobs rely on default permissions with
no `permissions:` block; several `template-injection` hits at `Info`/`help`
severity from `${{ }}` interpolated into `run:` blocks in
`lint.yaml`/`release.yaml`; a few `anonymous-definition` info notes) — but
none clear `--min-severity=medium --min-confidence=high`, so the gate
(matching `homelab-ops-terraform`'s exact invocation) passes clean with no
`zizmor.yaml` suppression file needed. Unlike `homelab-ops-terraform`, this
repo's `release.yaml`/`renovate.yaml` don't call `create-github-app-token`
directly — they pass `app_id`/`app_private_key` secrets into
`ppat/github-workflows` reusable workflows, so the `github-app` finding
pattern (which lives inside those reusable workflows' own files, not this
repo's) doesn't appear here at all.

Also verified while scoping this change: `actions/checkout` is already
pinned at `@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` at all 3
call sites (`test.yaml`, `release.yaml`, `lint.yaml`) — already current,
untouched. `actions/cache` is not used anywhere in this repo — nothing to
add.

## Findings table

| Finding | Severity/Confidence | Gate threshold met? | Decision |
| --- | --- | --- | --- |
| `excessive-permissions` (no `permissions:` block) — `release.yaml`, `renovate.yaml` (multiple jobs/workflow-level) | Medium severity / **Medium** confidence | No (needs High confidence) | Left as-is — below gate |
| `template-injection` — `lint.yaml` `terraform-dirs` step (`github.event_name`, `fromJSON(...)` interpolations) | Info/help severity | No (needs Medium+ severity) | Left as-is — below gate |
| `template-injection` — `release.yaml` (`secrets.CODER_EMAIL`/`CODER_PASSWORD` in `run:`, `github.repository` in `RELEASE_MSG`) | Info/help severity | No | Left as-is — below gate |
| `anonymous-definition` (job without `name:`) — `lint.yaml:terraform-dirs`, `release.yaml:publish-template`, `test.yaml:watchdog` | Info severity | No | Left as-is — below gate |

No suppression file (`zizmor.yaml`) was added, since nothing needed suppressing.

## Test plan

- [x] `pre-commit run --files .github/workflows/lint.yaml` — all hooks pass
- [x] `actionlint .github/workflows/lint.yaml` — only a pre-existing, unrelated `shellcheck` note in the untouched `terraform-dirs` job (confirmed present on `main` before this change too)
- [x] `uvx zizmor --format=plain --min-severity=medium --min-confidence=high --persona=regular .` (offline and with `GH_TOKEN`) — 0 findings
- [ ] CI green on this PR (the new `zizmor` job itself, plus existing lint jobs)