### PR TITLE
chore(github-actions): update ppat/github-workflows (v4.4.0 -> v5.0.1)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -71,7 +71,7 @@ jobs:
           TF_DIRS="[]"
           echo "No Terraform changes detected"
         fi
-        echo "dirs=$TF_DIRS" >> $GITHUB_OUTPUT
+        echo "dirs=$TF_DIRS" >> "$GITHUB_OUTPUT"
 
   commit-messages:
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   detect-changes:
-    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/detect-changed-files.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       # yamllint disable-line rule:indentation
       files_yaml: |
@@ -75,7 +75,7 @@ jobs:
 
   commit-messages:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-commit-messages.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref }}
       fetch_depth: ${{ github.event.pull_request.commits || 0 }}
@@ -85,7 +85,7 @@ jobs:
   github-actions:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-github-actions.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).actions_all_changed_files }}
@@ -93,7 +93,7 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).markdown_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).markdown_all_changed_files }}
@@ -101,21 +101,21 @@ jobs:
   docker-files:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).docker_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-hadolint.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-hadolint.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).docker_all_changed_files }}
       hadolint_config: .hadolint.yaml
 
   pre-commit:
-    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-pre-commit.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
 
   renovate-config-check:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).renovate_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-renovate-config-check.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).renovate_all_changed_files }}
@@ -123,7 +123,7 @@ jobs:
   shellcheck:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).shellscripts_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-shellcheck.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).shellscripts_all_changed_files }}
@@ -131,7 +131,7 @@ jobs:
   terraform:
     needs: [terraform-dirs]
     if: ${{ github.event_name != 'pull_request' || needs.terraform-dirs.outputs.terraform_dirs != '[]' }}
-    uses: ppat/github-workflows/.github/workflows/lint-terraform.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-terraform.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       tf_dirs: ${{ needs.terraform-dirs.outputs.terraform_dirs }}
@@ -139,7 +139,7 @@ jobs:
   yaml:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).yaml_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-yaml.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name != 'pull_request' && 'ALL' || fromJSON(needs.detect-changes.outputs.results).yaml_all_changed_files }}
@@ -147,6 +147,6 @@ jobs:
   zizmor:
     needs: [detect-changes]
     if: ${{ github.event_name != 'pull_request' || fromJSON(needs.detect-changes.outputs.results).actions_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/lint-zizmor.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       git_ref: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
       shell: bash
       # yamllint disable-line rule:indentation
       run: |
-        while ! curl -fsSL ${CODER_URL} > /dev/null; do
+        while ! curl -fsSL "${CODER_URL}" > /dev/null; do
           echo "Waiting for coder service to be ready... sleep 5s!"
           sleep 5
         done
@@ -93,7 +93,8 @@ jobs:
         echo
 
         echo "Generating authentication token..."
-        export CODER_SESSION_TOKEN=$(curl -X POST ${CODER_URL}/api/v2/users/login \
+        export CODER_SESSION_TOKEN
+        CODER_SESSION_TOKEN=$(curl -X POST "${CODER_URL}/api/v2/users/login" \
           -H 'Content-Type: application/json' \
           -H 'Accept: application/json' \
           --data '{"email": "'${{ secrets.CODER_EMAIL }}'", "password": "'${{ secrets.CODER_PASSWORD }}'"}' \
@@ -106,12 +107,13 @@ jobs:
         echo "Authentication token generated."
         echo
         echo "Determining coder version..."
-        export CODER_VERSION=$(curl -fsSL ${CODER_URL}/api/v2/buildinfo | jq -r .version | cut -d'+' -f1 | cut -d'v' -f2)
+        export CODER_VERSION
+        CODER_VERSION=$(curl -fsSL "${CODER_URL}/api/v2/buildinfo" | jq -r .version | cut -d'+' -f1 | cut -d'v' -f2)
         echo "Installing coder CLI..."
         curl -fsSL https://coder.com/install.sh | sh -s -- --method standalone --version "${CODER_VERSION}"
         echo
         echo "Logging into Coder..."
-        coder login --use-token-as-session ${CODER_URL}
+        coder login --use-token-as-session "${CODER_URL}"
 
     - name: Publish template
       id: publish-template
@@ -122,30 +124,33 @@ jobs:
       shell: bash
       # yamllint disable-line rule:indentation
       run: |
-        if echo $TEMPLATE_VERSION | grep -E '[0-9]+\.[0-9]+\.[0-9]+'; then
-          export TEMPLATE_NAME="$(echo ${TEMPLATE_DIR} | cut -d/ -f3)"
+        if echo "$TEMPLATE_VERSION" | grep -E '[0-9]+\.[0-9]+\.[0-9]+'; then
+          export TEMPLATE_NAME
+          TEMPLATE_NAME="$(echo "${TEMPLATE_DIR}" | cut -d/ -f3)"
           export RELEASE_MSG="[Release Notes](https://github.com/${{ github.repository }}/releases/tag/${TEMPLATE_VERSION})"
           export TEST_MODE=false
         else
-          export TEMPLATE_NAME="$(echo ${TEMPLATE_DIR} | cut -d/ -f3)-test"
+          export TEMPLATE_NAME
+          TEMPLATE_NAME="$(echo "${TEMPLATE_DIR}" | cut -d/ -f3)-test"
           export RELEASE_MSG="[Changes](https://github.com/${{ github.repository }}/commit/${TEMPLATE_VERSION})"
           export TEST_MODE=true
         fi
         echo "Publishing template ${TEMPLATE_DIR} as ${TEMPLATE_NAME}..."
         set -x
         coder template push \
-          --directory ${TEMPLATE_DIR} \
-          --var workspace_image=${WORKSPACE_IMAGE} \
+          --directory "${TEMPLATE_DIR}" \
+          --var "workspace_image=${WORKSPACE_IMAGE}" \
           --var test_mode=${TEST_MODE} \
-          --name ${TEMPLATE_VERSION} \
+          --name "${TEMPLATE_VERSION}" \
           --message "${RELEASE_MSG}" \
           --yes \
-          ${TEMPLATE_NAME}
+          "${TEMPLATE_NAME}"
         set +x
         echo
         echo "Confirming template has been published..."
         coder templates list --output json > /tmp/templates.json
-        export SELECTED_TEMPLATE=$(cat /tmp/templates.json | jq -r '.[] | select(.Template.name == "'${TEMPLATE_NAME}'")')
+        export SELECTED_TEMPLATE
+        SELECTED_TEMPLATE=$(cat /tmp/templates.json | jq -r '.[] | select(.Template.name == "'"${TEMPLATE_NAME}"'")')
         if [[ -z $SELECTED_TEMPLATE ]]; then
           echo "Could not find any template published as $TEMPLATE_NAME."
           exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   create-release:
-    uses: ppat/github-workflows/.github/workflows/release-semantic.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/release-semantic.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       dry_run: ${{ (github.event_name == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_publish == 'true') }}
       release_branch: ${{ github.head_ref || github.ref_name }}
@@ -39,7 +39,7 @@ jobs:
 
   publish-image:
     needs: [create-release]
-    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/build-docker-image.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       image_context_path: images/homelab-workspace
       label_title: "Homelab Workspace"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   renovate:
-    uses: ppat/github-workflows/.github/workflows/renovate.yaml@1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0
+    uses: ppat/github-workflows/.github/workflows/renovate.yaml@667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1
     with:
       dry_run: ${{ github.event_name == 'pull_request' }}
       git_ref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Summary

Bumps every `ppat/github-workflows` ref from v4.4.0 to **v5.0.1**
(`667d20d10c8756b11feeab1ee691825ccea8f991`, verified to resolve to the
`v5.0.1` tag) and fixes what v5 breaks in this repo, minimally.

Supersedes #876 (`chore(github-actions): update ppat/github-workflows
(v4.4.0 -> v5.0.0)`) — left open/untouched per instructions; please close
it manually once this merges.

Per standing instruction for this batch: this PR does **not** touch
`commitlint.config.js`/`scope-enum` and does **not** bump the
`renovate-presets` pin (stays `v0.2.1`).

## Refs bumped (14 occurrences, all confirmed gone from the old pin)

`1e8ca1b00b6e69bdf5aef8b33111c594c051ff65 # v4.4.0` → `667d20d10c8756b11feeab1ee691825ccea8f991 # v5.0.1`

- `.github/workflows/renovate.yaml` — 1x (`renovate.yaml`)
- `.github/workflows/lint.yaml` — 11x (`detect-changed-files.yaml`,
  `lint-commit-messages.yaml`, `lint-github-actions.yaml`,
  `lint-markdown.yaml`, `lint-hadolint.yaml`, `lint-pre-commit.yaml`,
  `lint-renovate-config-check.yaml`, `lint-shellcheck.yaml`,
  `lint-terraform.yaml`, `lint-yaml.yaml`, `lint-zizmor.yaml`)
- `.github/workflows/release.yaml` — 2x (`release-semantic.yaml`,
  `build-docker-image.yaml`)

`workflow_call.inputs` for every called workflow was diffed v4.4.0→v5.0.1:
no renames or removals affect any call site here. `lint-zizmor.yaml`
gained four new optional inputs (`advisory_only`, `min_confidence`,
`min_severity`, `persona`), all defaulting to current behavior — not
adopted, since this batch is scoped to "make v5 work," not "adopt every
new knob."

## Why anything needed fixing: actionlint's shellcheck integration

v5's `lint-github-actions.yaml` bumps `actionlint` v1.7.4 → v1.7.12,
which turns on `actionlint -shellcheck`'s integration — previously inert
because `set -x` style debug output made it look like it ran, but
`actionlint` never actually invoked shellcheck under v4. This is the
first real shellcheck pass over this repo's own workflow `run:` blocks
(the reusable workflows in `ppat/github-workflows` were already fixed
upstream). **actionlint appends `--norc`, so this repo's
`.shellcheckrc` does not filter these findings** — every finding had to
be triaged inline.

Reproduced locally exactly as v5's `lint-github-actions.yaml` runs it:
`actionlint -shellcheck shellcheck` (mise-pinned to the exact versions
v5 pins: actionlint v1.7.12, shellcheck v0.11.0), over this repo's
`.github/workflows/*.yaml`.

### Findings (18 total) — all fixed, none suppressed

| File / job | Finding | Fix | Why safe |
|---|---|---|---|
| `lint.yaml` — `terraform-dirs` (pre-existing) | `SC2086` on `>> $GITHUB_OUTPUT` | Quoted: `>> "$GITHUB_OUTPUT"` | Redirection target, not argv — bash never word-splits it. |
| `release.yaml` — Login to Coder | 4x `SC2086` on `${CODER_URL}` (curl ×3, `coder login`) | Quoted each | `CODER_URL` is a single secret URL, never a list — quoting a scalar can't change argv count. |
| `release.yaml` — Login to Coder | 2x `SC2155` on `export CODER_SESSION_TOKEN=$(curl ...)`, `export CODER_VERSION=$(curl ...)` | Split into `export VAR` + `VAR=$(...)` | Declare/assign-separation only changes behavior if the caller checks the subshell's exit status via the `export` line — nothing here does (no `set -e`, no `$?` check). |
| `release.yaml` — Publish template | 8x `SC2086` on `${TEMPLATE_DIR}`, `${TEMPLATE_VERSION}`, `${TEMPLATE_NAME}`, `${WORKSPACE_IMAGE}` (in `coder template push` args, the `if echo $TEMPLATE_VERSION` check, and inside a `jq` filter string) | Quoted each | All scalars (a path, a semver/sha, an image ref) — none are ever space-separated lists. |
| `release.yaml` — Publish template | 3x `SC2155` on `export TEMPLATE_NAME=...` (×2), `export SELECTED_TEMPLATE=$(...)` | Split into declare + assign | Same reasoning as above. |

**Not touched:** `--var test_mode=${TEST_MODE}` was left unquoted.
Shellcheck does not flag it — `TEST_MODE` is only ever assigned the
literal `true`/`false`, so shellcheck's flow analysis already proves it
safe — and quoting it would be an unrequested change with no finding
behind it.

**No `# shellcheck disable=` was needed anywhere.** The word-splitting
carve-out (SC2086/SC2046/SC2016/SC2154 left alone when a variable
deliberately holds a space-separated list that must expand to N argv
elements — see upstream's `${ACTIONS_FILES}`/`${SHELLSCRIPT_FILES}`/
`${DOCKER_FILES}` handling) doesn't apply to any finding here: none of
this repo's local `run:` blocks build an argv list from a
space-separated variable.

### Argv-equivalence proof

Ran a stub (`coder`/`curl`/`jq` replaced with argv-echoing functions)
against representative values for every quoted variable — before vs.
after produced **byte-identical argv**, for both the `coder template
push \ --directory ... --var ... --name ... "${TEMPLATE_NAME}"` line and
the `curl`/`coder login`/`jq` calls in the Login step. Also demonstrated
the pathological case (a value containing a space) to show the fix is
strictly *safer*, not merely equivalent, without changing token count
for any real-world input:

```
BEFORE (unquoted): --var workspace_image=registry.example.com/path/coder workspace:1.2.3
  → ARGC=5: ... --var  workspace_image=registry.example.com/path/coder  workspace:1.2.3   (silently split into 2 args)
AFTER (quoted):    --var "workspace_image=registry.example.com/path/coder workspace:1.2.3"
  → ARGC=4: ... --var  workspace_image=registry.example.com/path/coder\ workspace:1.2.3   (stays 1 arg)
```

For normal (space-free) values, `ARGC`/`ARGV[]` are identical in both
forms — confirmed for `coder template push` (14 argv elements, byte
match) and all three `curl` calls.

## Also verified

- `actionlint -shellcheck shellcheck` over all `.github/workflows/*.yaml`: **0 findings**, exit 0 (was 18 findings, exit 1, before the fix commit).
- `yamllint -c .yamllint --strict` (pinned 1.38.0, matches v5's pin) on the changed files: clean.
- `zizmor --format=github --min-severity=medium --min-confidence=high --persona=regular .` (pinned v1.29.0, matches v5's pin): 0 findings.
- `pre-commit` hooks (as configured in this repo) passed on both commits.

## Other v5 changes not applicable / not adopted here

- `lint-shellcheck.yaml`'s file-selection change (executable-bit only →
  executable **and** shebang/extension-filtered): simulated both
  selectors against this repo's files. Only 2 files carry the
  executable bit (`script-memory-watchdog-test.sh`,
  `script-prepare-workspace.sh`), and both already end in `.sh`, so the
  **linted file set is identical before and after** — no coverage
  change, no explanation needed beyond that. (This job is path-gated
  out of this PR since no `.sh` files changed — see CI section below.)
- `lint-shellcheck.yaml`'s new PASS/FAIL-per-file output and
  `renovate-config-validator` bump (44.14.12 → 44.30.4): internal to the
  reusable workflow, nothing in this repo needed to change.
- `lint-zizmor.yaml`'s four new optional inputs: not adopted (all
  default to current behavior; out of scope for "just the bump").

## CI status

Job naming and which run verified what:

*(filled in after push — see follow-up comment)*
